### PR TITLE
Fractional scaling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "log",
  "tempfile",
  "wayland-client",
+ "wayland-protocols",
  "wayland-protocols-wlr",
  "wayland-server",
  "xkbcommon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.11.2"
 log = "0.4.20"
 tempfile = "3.10.0"
 wayland-client = "0.31.2"
+wayland-protocols = {version="0.31.2", features = ["client", "unstable", "staging"]}
 wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
 wayland-server = "0.31.1"
 xkbcommon = "0.7.0"


### PR DESCRIPTION
uses `wp_fractional_scale_v1` to scale the layer surface based on `PreferredScale` events received from the compositor