### PR TITLE
Big refactor & add cmd arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,38 +10,58 @@ Run `wayfreeze`, click or press escape to exit.
 Usage: wayfreeze [OPTIONS]
 
 Options:
-      --hide-cursor  Hide cursor when freezing the screen
-  -h, --help         Print help
-  -V, --version      Print version
+      --hide-cursor
+          Hide cursor when freezing the screen
+      --before-freeze-cmd <BEFORE_FREEZE_CMD>
+          Command to run before freezing the screen
+      --before-freeze-timeout <BEFORE_FREEZE_TIMEOUT>
+          Amount of milliseconds to wait between before-freeze-cmd and freezing the screen
+      --after-freeze-cmd <AFTER_FREEZE_CMD>
+          Command to run after freezing the screen
+      --after-freeze-timeout <AFTER_FREEZE_TIMEOUT>
+          Amount of milliseconds to wait between freezing the screen and running after-freeze-cmd
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 Example usage with [Grim](https://git.sr.ht/~emersion/grim) & [Slurp](https://github.com/emersion/slurp):
 
 ```bash
+# for e.g. Hyprland:
 wayfreeze & PID=$!; sleep .1; grim -g "$(slurp)" - | wl-copy; kill $PID
-# or
-$(grim -g "$(slurp)" - | wl-copy; killall wayfreeze) & sleep .1; wayfreeze
+# or:
+wayfreeze --after-freeze-cmd 'grim -g "$(slurp)" - | wl-copy; killall wayfreeze'
+
+# for e.g. Sway:
+wayfreeze --before-freeze-cmd 'grim -g "$(slurp)" - | wl-copy; killall wayfreeze' --before-freeze-timeout 10"
 ```
 
-> Note: the Wayland specification [states the following](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:enum:layer): "Multiple surfaces can share a single layer, and ordering within a single layer is undefined." This means that compositors can put new layer surfaces **over or under** existing layer surfaces (given they're on the same layer), and **both of those options are compliant to the spec**. That's why there are 2 example commands provided: the first one works on compositors like e.g. Hyprland (where new layer surfaces appear over older ones), while the second one works on e.g. Sway (which puts new layer surfaces underneath already existing ones).
+> Note: the Wayland specification [states the following](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:enum:layer): "Multiple surfaces can share a single layer, and ordering within a single layer is undefined." This means that compositors can put new layer surfaces **over or under** existing layer surfaces (given they're on the same layer), and **both of those options are compliant to the spec**. Compositors like e.g. Hyprland put new layer surfaces over older ones, while e.g. Sway puts new layer surfaces underneath already existing ones. If you're unsure how your compositor handles this, just try both commands while playing a video or something. One will work, the other one won't.
 
 ## Installing
 
 Wayfreeze can be installed either by using nixpkgs-unstable or flake.
 
 ### Nixpkgs:
+
 Add this to your configuration and rebuild your system:
+
 ```nix
 environment.systemPackages = [ pkgs.wayfreeze ];
 ```
 
 ### Flake:
+
 Add this repository as a flake to your inputs:
+
 ```nix
 wayfreeze.url = "github:jappie3/wayfreeze";
 ```
 
 Define the package and then rebuild your system:
+
 ```nix
 environment.systemPackages = [ inputs.wayfreeze.packages.${pkgs.system}.wayfreeze ];
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,16 +403,12 @@ impl Dispatch<wl_shm::WlShm, ()> for AppData {
 impl Dispatch<wl_buffer::WlBuffer, ()> for AppData {
     fn event(
         _state: &mut Self,
-        proxy: &wl_buffer::WlBuffer,
-        event: <wl_buffer::WlBuffer as Proxy>::Event,
+        _proxy: &wl_buffer::WlBuffer,
+        _event: <wl_buffer::WlBuffer as Proxy>::Event,
         _data: &(),
         _connection: &wayland_client::Connection,
         _queue_handle: &wayland_client::QueueHandle<Self>,
     ) {
-        if let wl_buffer::Event::Release = event {
-            debug!("| Received wl_buffer::Event::Release");
-            proxy.destroy();
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,10 +223,6 @@ impl Dispatch<wl_output::WlOutput, usize> for AppData {
         } = event
         {
             debug!("| Received wl_output::Event::Mode for output {}", data);
-            trace!(
-                "  this is output number {}",
-                state.outputs.as_ref().map(|v| v.len()).unwrap_or(0)
-            );
             // describes an available output mode for the output
 
             // save the width & height of this output under the same key as this output's index in the vector
@@ -735,6 +731,7 @@ impl ScreenFreezer {
         };
 
         // create screencopy frame, copy screen contents to buffer
+        info!("> Processing {} output(s)", outputs.len());
         for i in 0..outputs.len() as i64 {
             trace!("  processing output {}", i);
 
@@ -777,6 +774,7 @@ impl ScreenFreezer {
             vec_insert(&mut self.state.screencopy_frames, i, screencopy_frame);
             vec_insert(&mut self.state.shm_pools, i, pool);
         }
+        info!("> Processed {} output(s)", outputs.len());
 
         // wait for all frames to be copied & run before-freeze commands
         loop {
@@ -803,6 +801,7 @@ impl ScreenFreezer {
         };
 
         // create & configure layer surface, attach buffer to it, fractional scaling & some cleanup
+        info!("> Creating {} layer surface(s)", outputs.len());
         for i in 0..outputs.len() as i64 {
             let Some(surfaces) = &self.state.surfaces else {
                 error!("No WlSurface loaded");

--- a/src/main.rs
+++ b/src/main.rs
@@ -919,16 +919,16 @@ struct Args {
     #[arg(long, required = false, default_value_t = false)]
     hide_cursor: bool,
     /// Command to run before freezing the screen.
-    #[arg(long, required = false, default_value = "")]
+    #[arg(long, hide_default_value = true, required = false, default_value = "")]
     before_freeze_cmd: String,
     /// Amount of milliseconds to wait between before-freeze-cmd and freezing the screen.
-    #[arg(long, required = false, default_value_t = 0)]
+    #[arg(long, hide_default_value = true, required = false, default_value_t = 0)]
     before_freeze_timeout: u64,
     /// Command to run after freezing the screen.
-    #[arg(long, required = false, default_value = "")]
+    #[arg(long, hide_default_value = true, required = false, default_value = "")]
     after_freeze_cmd: String,
     /// Amount of milliseconds to wait between freezing the screen and running after-freeze-cmd.
-    #[arg(long, required = false, default_value_t = 0)]
+    #[arg(long, hide_default_value = true, required = false, default_value_t = 0)]
     after_freeze_timeout: u64,
 }
 


### PR DESCRIPTION
Big refactor to avoid problems with layer surface ordering (which is up to the compositor, according to the Wayland specification). Also adds 4 new arguments:

```
--before-freeze-cmd <BEFORE_FREEZE_CMD>
    Command to run before freezing the screen [default: ]
--before-freeze-timeout <BEFORE_FREEZE_TIMEOUT>
    Amount of milliseconds to wait between before-freeze-cmd and freezing the screen [default: 0]
--after-freeze-cmd <AFTER_FREEZE_CMD>
    Command to run after freezing the screen [default: ]
--after-freeze-timeout <AFTER_FREEZE_TIMEOUT>
    Amount of milliseconds to wait between freezing the screen and running after-freeze-cmd [default: 0]
```

`before-freeze` allows you to run commands before Wayfreeze creates a layer surface (but after it has already copied the screen), while `after-freeze` is for running things after the screen has been frozen, but before Wayfreeze has exited.